### PR TITLE
Fix stray character in chatbot JS

### DIFF
--- a/js/chatbotArbol.js
+++ b/js/chatbotArbol.js
@@ -1021,7 +1021,7 @@ class ChatBotHibrido {
             this.mostrarAyuda();
         } else {
             this.mostrarOpcionesActuales();
-        } º
+        }
     }
 
     volverAlInicio() {


### PR DESCRIPTION
## Summary
- remove an accidental `º` left in `chatbotArbol.js`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68503d0258d08322b6e4445c1ae43f97