### PR TITLE
Fix speech manager comment

### DIFF
--- a/js/speechManager.js
+++ b/js/speechManager.js
@@ -155,8 +155,7 @@ export class SpeechManager {
       utterance.pitch = options.pitch || emotion.pitch;
       utterance.volume = options.volume || 0.8;
 
-      // ¡AQUÍ ESTÁ LA PARTE QUE FALTA!
-      // Eventos del utterance
+      // Configurar eventos del utterance para monitorear el proceso de voz
       utterance.onstart = () => {
         console.log('🗣️ Comenzando a hablar:', text.substring(0, 50) + '...');
         this.currentUtterance = utterance;


### PR DESCRIPTION
## Summary
- clarify the comment in `speak` to document the event setup

## Testing
- `npm test` *(fails: ENOENT: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68503d032b048322a977a9fb70232294